### PR TITLE
Replaced instances of WARN_PRINTS with WARN_PRINT

### DIFF
--- a/kehnetwork/entityinfo.cpp
+++ b/kehnetwork/entityinfo.cpp
@@ -316,7 +316,7 @@ Node* kehEntityInfo::spawn_node(uint32_t uid, uint32_t chash)
    }
    else
    {
-      WARN_PRINTS(vformat("Could not retrieve spawner for entity '%s' with unique ID %d", m_namestr, uid));
+      WARN_PRINT(vformat("Could not retrieve spawner for entity '%s' with unique ID %d", m_namestr, uid));
    }
 
    return ret;

--- a/kehnetwork/propcomparer.cpp
+++ b/kehnetwork/propcomparer.cpp
@@ -44,7 +44,7 @@ struct TheComparer : public CProxy
 template <>
 struct TheComparer<float, true, false> : public CProxy
 {
-   bool compare(const Variant& var1, const Variant& var2) const { return Math::is_equal_approx(var1, var2); }
+   bool compare(const Variant& var1, const Variant& var2) const { return Math::is_equal_approx(float(var1), float(var2)); }
    String get_comp_name() const { return "float_auto"; }
 
    static Ref<TheComparer> create() { return memnew(TheComparer); }

--- a/kehnetwork/snapshotdata.cpp
+++ b/kehnetwork/snapshotdata.cpp
@@ -75,7 +75,7 @@ void kehSnapshotData::register_entity_types()
          }
          else
          {
-            WARN_PRINTS(vformat("Skipping registration of class '%s' (%d). Reason: %s", cname, info->get_name_hash(), err))
+            WARN_PRINT(vformat("Skipping registration of class '%s' (%d). Reason: %s", cname, info->get_name_hash(), err))
          }
       }
    }

--- a/kehnetwork/snapshotdata.cpp
+++ b/kehnetwork/snapshotdata.cpp
@@ -75,7 +75,7 @@ void kehSnapshotData::register_entity_types()
          }
          else
          {
-            WARN_PRINT(vformat("Skipping registration of class '%s' (%d). Reason: %s", cname, info->get_name_hash(), err))
+            WARN_PRINT(vformat("Skipping registration of class '%s' (%d). Reason: %s", cname, info->get_name_hash(), err));
          }
       }
    }


### PR DESCRIPTION
WARN_PRINTS is outdated and was phased out of Godot 3.x in 2020. WARN_PRINT does the same thing, and allows module to compile with 3.x versions